### PR TITLE
Alter Start react script for Legacy Support

### DIFF
--- a/ontour/package.json
+++ b/ontour/package.json
@@ -46,7 +46,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This change is to make the dependencies more compatible with newer versions of npm and node, as used by the Fall 2023 capstone team. The start is the only react script altered. 