### PR TITLE
deleted react-google-maps

### DIFF
--- a/ontour/package.json
+++ b/ontour/package.json
@@ -31,7 +31,7 @@
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
-    "react-google-maps": "^9.4.5",
+
     "react-helmet": "^6.1.0",
     "react-icons": "^4.4.0",
     "react-loading-icons": "^1.1.0",


### PR DESCRIPTION
deleted unused react-google-maps package in package.json to prevent version conflict when doing npm install